### PR TITLE
Add .vscode and .idx to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@
 .DS_Store
 *.pem
 
+# editor settings
+.vscode/
+.idx/
+
 # debug
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
Adds .vscode/ and .idx/ editor settings directories to .gitignore to prevent tracking editor-specific configuration files.

Resolves #2

Generated with [Claude Code](https://claude.ai/code)